### PR TITLE
Refine exit confirmation dialog

### DIFF
--- a/extension/textext/asktext.py
+++ b/extension/textext/asktext.py
@@ -771,15 +771,24 @@ if TOOLKIT in (GTK, GTKSOURCEVIEW):
             self.update_position_label(text_buffer, view)
 
         def window_deleted_cb(self, widget, event, view):
-            if self._gui_config.get("confirm_close", self.DEFAULT_CONFIRM_CLOSE) and \
-               self._source_buffer.get_text(self._source_buffer.get_start_iter(), self._source_buffer.get_end_iter()) \
-                    != self.text:
-                dlg = gtk.MessageDialog(self._window, gtk.DIALOG_MODAL, gtk.MESSAGE_QUESTION, gtk.BUTTONS_YES_NO,
-                                   "You made text changes, do you really want to close TexText?")
-                dlg.set_title("Discard changes?")
+            if (self._gui_config.get("confirm_close", self.DEFAULT_CONFIRM_CLOSE)
+                    and self._source_buffer.get_text(self._source_buffer.get_start_iter(),
+                                                     self._source_buffer.get_end_iter()) != self.text):
+                dlg = gtk.MessageDialog(self._window, gtk.DIALOG_MODAL, gtk.MESSAGE_QUESTION, gtk.BUTTONS_NONE)
+                dlg.set_markup(
+                    "<b>Do you want to close TexText without save?</b>"
+                    "Your changes will be lost if you don't save them."
+                )
+                dlg.add_button("Cancel", gtk.RESPONSE_CANCEL).set_image(
+                    gtk.image_new_from_stock(gtk.STOCK_GO_BACK, gtk.ICON_SIZE_BUTTON)
+                )
+                dlg.add_button("Close without save", gtk.RESPONSE_CLOSE).set_image(
+                    gtk.image_new_from_stock(gtk.STOCK_CLOSE, gtk.ICON_SIZE_BUTTON)
+                )
+                dlg.set_title("Close without save?")
                 res = dlg.run()
                 dlg.destroy()
-                if res == gtk.RESPONSE_NO:
+                if res == gtk.RESPONSE_CANCEL:
                     return True
 
             gtk.main_quit()

--- a/extension/textext/asktext.py
+++ b/extension/textext/asktext.py
@@ -779,7 +779,7 @@ if TOOLKIT in (GTK, GTKSOURCEVIEW):
                     "<b>Do you want to close TexText without save?</b>"
                     "Your changes will be lost if you don't save them."
                 )
-                dlg.add_button("Cancel", gtk.RESPONSE_CANCEL).set_image(
+                dlg.add_button("Continue editing", gtk.RESPONSE_CANCEL).set_image(
                     gtk.image_new_from_stock(gtk.STOCK_GO_BACK, gtk.ICON_SIZE_BUTTON)
                 )
                 dlg.add_button("Close without save", gtk.RESPONSE_CLOSE).set_image(


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/2975991/59956131-0799c000-9497-11e9-8476-1b79e0ff16b0.png)


Short checklist:
- [x] Tested with Inkscape version: [fill in Inkscape version here]
- [x] Tested on Linux, Distro: [fill in distribution name here]
- [ ] Tested on Windows, Version: [fill in Windows version here]
- [ ] Tested on MacOS, Version:  [fill in MacOS version/ name here]
